### PR TITLE
update with changes from deccaxon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ setup(
     install_requires=[
         'requests'
     ],
+    tests_require=[
+        'mock',
+        'pylint',
+    ],
+    test_suite='tests.test_ca',
     scripts=[],
     zip_safe=False,
     packages=find_packages()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,39 @@
+
+import json
+import mock
+import requests
+import unittest
+
+from StringIO import StringIO
+
+class BaseTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self._patches = []
+
+    def tearDown(self):
+        self._unpatchall()
+
+    def _patchfun(self, name):
+        patch = mock.patch(name)
+        self._patches.append(patch)
+        return patch.start()
+
+    def _patchobj(self, cls, member):
+        patch = mock.patch.object(cls, member)
+        self._patches.append(patch)
+        return patch.start()
+
+    def _unpatchall(self):
+        for patch in self._patches:
+            patch.stop()
+
+    @staticmethod
+    def http_response(code, headers=None, body=None):
+        resp = requests.Response()
+        resp.status_code = code
+        if headers:
+            resp.headers.update(headers)
+        if body:
+            resp.raw = StringIO(json.dumps(body))
+        return resp

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -1,0 +1,91 @@
+
+import json
+import logging
+import mock
+import requests
+from vaultlib.ca import VaultCA
+from tests import BaseTestCase
+
+LOG = logging.getLogger(__name__)
+
+class TestVaultCA(BaseTestCase):
+
+    def setUp(self):
+        super(TestVaultCA, self).setUp()
+        self._request = self._patchobj(requests.sessions.Session, 'request')
+        self._url = 'http://fake:8200'
+        self._ca = VaultCA(self._url, 'fake-token', 'my_ca_pref/myca', 'myca')
+
+    def _check(self, verb, path, body_checks=None):
+        call_verb = self._request.call_args[0][0]
+        call_url = self._request.call_args[0][1]
+        self.assertEqual(verb, call_verb)
+        self.assertEqual('%s/v1/%s' % (self._url, path), call_url)
+
+        if body_checks:
+            call_data = json.loads(self._request.call_args[1]['data'])
+            for body_check in body_checks:
+                body_check(call_data)
+
+    def test_create_ca(self):
+        self._request.return_value = self.http_response(204, {}, {})
+        self._ca.create_ca('This is my ca', maxttl='10h')
+        self._check('POST', 'sys/mounts/my_ca_pref/myca', body_checks=[
+            lambda b: self.assertEqual('pki', b['type'])
+        ])
+
+    def test_delete_ca(self):
+        self._request.return_value = self.http_response(200, {}, {})
+        self._ca.delete_ca()
+        self._check('DELETE', 'sys/mounts/my_ca_pref/myca')
+
+    def test_new_ca_root(self):
+        self._request.side_effect = [self.http_response(200, {}, {}),
+                                     self.http_response(200, {}, {})]
+        self._ca.new_ca_root('myca')
+        self._request.assert_has_calls([
+            mock.call('DELETE', 'http://fake:8200/v1/my_ca_pref/myca/root', data=None),
+            mock.call('POST',
+                      'http://fake:8200/v1/my_ca_pref/myca/root/generate/internal',
+                      data='{"common_name": "myca", "ttl": "8760h"}')
+        ])
+
+    def test_create_signing_role(self):
+        self._request.return_value = self.http_response(204, {}, {})
+        self._ca.create_signing_role('myrole')
+        self._check('POST', 'my_ca_pref/myca/roles/myrole')
+
+    def test_create_signing_token_policy(self):
+        self._request.return_value = self.http_response(204, {}, {})
+        self._ca.create_signing_token_policy('myrole', 'mypolicy')
+        def _check_policy(body):
+            policy = body['policy']
+            self.assertTrue(policy.startswith('path "my_ca_pref/myca/sign/myrole"'))
+
+        self._check('PUT', 'sys/policy/mypolicy', body_checks=[_check_policy])
+
+    def test_create_token(self):
+        self._request.return_value = self.http_response(204, {}, {})
+        self._ca.create_token('mypolicy')
+        self._check('POST', 'auth/token/create', body_checks=[
+            lambda b: self.assertEqual(['mypolicy'], b['policies'])
+        ])
+
+    def test_sign_csr(self):
+        self._request.return_value = self.http_response(201, {}, {})
+        self._ca.sign_csr('myrole', 'csr_pem_string',
+                          alt_names=['larry', 'moe', 'curly'])
+        self._check('POST', 'my_ca_pref/myca/sign/myrole', body_checks=[
+            lambda b: self.assertEqual('csr_pem_string', b['csr']),
+            lambda b: self.assertEqual('larry,moe,curly', b['alt_names'])
+        ])
+
+    def test_ca_pref_parse(self):
+        self.assertEqual('myca', self._ca._common_name)
+        self.assertEqual('my_ca_pref/myca', self._ca._ca_func_path)
+        self.assertEqual('sys/mounts/my_ca_pref/myca', self._ca._ca_mount_path)
+
+        no_pref_ca = VaultCA(self._url, 'fake-token', 'myca', 'myca')
+        self.assertEqual('myca', no_pref_ca._common_name)
+        self.assertEqual('myca', no_pref_ca._ca_func_path)
+        self.assertEqual('sys/mounts/myca', no_pref_ca._ca_mount_path)

--- a/vaultlib/ca.py
+++ b/vaultlib/ca.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from copy import deepcopy
@@ -7,9 +6,16 @@ from requests.exceptions import HTTPError
 
 LOG = logging.getLogger(__name__)
 
-class VaultCA(VaultBase):
 
-    def create_ca(self, ca_name, description, maxttl='8760h'):
+class VaultCA(VaultBase):
+    def __init__(self, vault_addr, vault_token, vault_pki_path, customer_shortname):
+        super(VaultCA, self).__init__(vault_addr, vault_token)
+
+        self._common_name = customer_shortname
+        self._ca_func_path = vault_pki_path
+        self._ca_mount_path = 'sys/mounts/' + self._ca_func_path
+
+    def create_ca(self, description, maxttl='8760h'):
         """
         Create a new CA in vault. If it already exists, do nothing.
         """
@@ -17,47 +23,49 @@ class VaultCA(VaultBase):
             'type': 'pki',
             'description': description,
             'config': {'max_lease_ttl': maxttl}
-         }
+        }
 
-        LOG.info('Mounting pki vault backend at \'%s\'.', ca_name)
+        LOG.info('Mounting pki vault backend at \'%s\'.', self._ca_mount_path)
         try:
-            self.rq('POST', 'sys/mounts/%s' % ca_name, body)
+            self.rq('POST', self._ca_mount_path, body)
         except HTTPError as e:
-            already_exists = 'existing mount' in e.response.text
+            already_exists = ('existing mount' in e.response.text or
+                              'already in use' in e.response.text)
             if already_exists:
                 pass
             else:
                 raise
 
-    def get_ca(self, ca_name):
+    def get_ca(self):
         """
         Get the cert for a named CA.
         """
-        LOG.info('Fetching CA cert for \'%s\'', ca_name)
-        return self.rq('GET', '%s/cert/ca' % ca_name)
+        LOG.info('Fetching CA cert for \'%s\'', self._ca_func_path)
+        return self.rq('GET', '%s/cert/ca' % self._ca_func_path)
 
-    def delete_ca(self, ca_name):
+    def delete_ca(self):
         """
         Delete a named CA
         """
         LOG.info('Removing CA and invalidating all certs signed by \'%s\'',
-                 ca_name)
-        return self.rq('DELETE', 'sys/mounts/%s' % ca_name)
+                 self._ca_func_path)
+        return self.rq('DELETE', self._ca_mount_path)
 
-    def new_ca_root(self, ca_name, common_name=None, ttl='8760h'):
+    def new_ca_root(self, common_name=None, ttl='8760h'):
         """
         Add or replace a root certificate in the named CA.
         """
-        self.rq('DELETE','%s/root' % ca_name)
+        self.rq('DELETE', '%s/root' % self._ca_func_path)
+
         body = {
-            'common_name': common_name or ca_name,
+            'common_name': common_name or self._common_name,
             'ttl': ttl
         }
         LOG.info('Adding or replacing CA certificate for \'%s\' '
-                 'with common name \'%s\'.', ca_name, common_name)
-        return self.rq('POST', '%s/root/generate/internal' % ca_name, body)
+                 'with common name \'%s\'.', self._ca_func_path, common_name)
+        return self.rq('POST', '%s/root/generate/internal' % self._ca_func_path, body)
 
-    def create_signing_role(self, ca_name, role_name, options=None):
+    def create_signing_role(self, role_name, options=None):
         """
         Create a signing role containing a set of default options for certs
         signed by this CA. See https://www.vaultproject.io/api/secret/pki/index.html#create-update-role
@@ -75,21 +83,24 @@ class VaultCA(VaultBase):
         })
         LOG.info('Creating a new signing role \'%s\' for \'%s\'',
                  role_name,
-                 ca_name)
-        return self.rq('POST', '%s/roles/%s' % (ca_name, role_name), body)
+                 self._ca_func_path)
+        return self.rq('POST', '%s/roles/%s' % (self._ca_func_path, role_name), body)
 
-    def create_signing_token_policy(self, ca_name, role_name, policy_name):
+    def create_signing_token_policy(self, role_name, policy_name):
         """
         Create an access policy associated with the ability to sign certs
         with the given ca_name and role. This policy can be used to create
         limited-access authentication tokens.
         """
-        capabilities=['create', 'read', 'update', 'delete', 'list']
+        capabilities = ['create', 'read', 'update', 'delete', 'list']
+
         policy = 'path \"%s/sign/%s\" {capabilities = [%s]}' % \
-            (ca_name, role_name, ','.join(['\"%s\"' % c for c in capabilities]))
+                 (self._ca_func_path, role_name, ','.join(['\"%s\"' % c for c in capabilities]))
+
         body = {"name": policy_name, "policy": policy}
+
         LOG.info('Creating access policy \'%s\' on CA \'%s\' for role \'%s\' ',
-                 policy_name, ca_name, role_name)
+                 policy_name, self._common_name, role_name)
         return self.rq('PUT', 'sys/policy/%s' % policy_name, body)
 
     def create_token(self, policy_name):
@@ -99,9 +110,9 @@ class VaultCA(VaultBase):
         LOG.info('Creating a new vault access token for with policy \'%s\'',
                  policy_name)
         return self.rq('POST', 'auth/token/create',
-                        {'policies': [policy_name]})
+                       {'policies': [policy_name]})
 
-    def sign_csr(self, ca_name, role, csr_pem, common_name=None, ip_sans=None,
+    def sign_csr(self, role, csr_pem, common_name=None, ip_sans=None,
                  alt_names=None, ttl='730h'):
         """
         Sign a PEM-encoded CSR.
@@ -118,6 +129,6 @@ class VaultCA(VaultBase):
             body['ip_sans'] = ','.join(ip_sans)
 
         LOG.info('Requesting a new certificate from \'%s\' for role \'%s\' '
-                 'for common_name = \'%s\'', ca_name, role,
+                 'for common_name = \'%s\'', self._ca_func_path, role,
                  common_name or 'unknown')
-        return self.rq('POST', '%s/sign/%s' % (ca_name, role), body)
+        return self.rq('POST', '%s/sign/%s' % (self._ca_func_path, role), body)


### PR DESCRIPTION
This mirrors my changes from deccaxon that make the VaultCA class expect an explicit path to the pki engine in vault. Also, copies over the tests that were written for this code in deccaxon.

Once this is validated along with its one current consumer, vouch, then we can replace the code in deccaxon with this library.